### PR TITLE
Add repo metadata for team: software-engineering

### DIFF
--- a/.repo-metadata.yaml
+++ b/.repo-metadata.yaml
@@ -1,0 +1,3 @@
+version: 1.1
+jira-project: ENG
+team: software-engineering


### PR DESCRIPTION
This PR adds a `.repo-metadata.yaml` file if it was missing.