### PR TITLE
docs: Set CODEOWNERS to engineering maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @invitation-homes/engineering-maintainers


### PR DESCRIPTION
Update CODEOWNERS file to specify developers as the code owner for this repository. This will bring this repo in compliance with our decision on CODEOWNERS files found here https://github.com/invitation-homes/technology-decisions/blob/main/0004-github-conventions.md#repository-ownership-1

Jira: RES-281