### PR TITLE
RES-282 Remove deprecated .repo-metadata.yaml file

### DIFF
--- a/.repo-metadata.yaml
+++ b/.repo-metadata.yaml
@@ -1,3 +1,0 @@
-version: 1.1
-jira-project: ENG
-team: software-engineering


### PR DESCRIPTION
## Summary
Remove the deprecated `.repo-metadata.yaml` file from this repository.

## Why
This file is no longer used. Repository metadata is now managed through GitHub's native CODEOWNERS file for ownership

## Changes
- Deleted `.repo-metadata.yaml` file